### PR TITLE
メッセージをUIに表示させる

### DIFF
--- a/lib/providers/speech_notifier_provider.dart
+++ b/lib/providers/speech_notifier_provider.dart
@@ -22,14 +22,7 @@ class SpeechNotifier extends StateNotifier<SpeechState> {
   }
 
   void _initSpeech() async {
-    bool available = await _speechToText.initialize(
-      onStatus: (status) {
-        debugPrint('status: $status');
-      },
-      onError: (errorNotification) {
-        debugPrint('error: $errorNotification');
-      },
-    );
+    bool available = await _speechToText.initialize();
     state = state.copyWith(isSpeechEnabled: available);
   }
 

--- a/lib/ui/screens/ai_screen/voice_screen.dart
+++ b/lib/ui/screens/ai_screen/voice_screen.dart
@@ -12,7 +12,7 @@ class SpeechState {
   SpeechState({
     this.lastWords = '',
     this.isListening = false,
-    this.isSpeechEnabled = true,
+    this.isSpeechEnabled = false,
   });
 }
 


### PR DESCRIPTION
## 変更点

- 自分のメッセージが送信されると、帰ってきたメッセージが下に表示される
- 1秒で送信すると、うまく音声が認識されないため、ユーザーが喋り終わってからメッセージを送信するまでの時間を2秒に変更しました
- 帰ってきたメッセージが表示されるコンテナの位置を、文章の長さを考慮して少し上に変更しました