### PR TITLE
Home_Screenに遷移する度に読み上げ済の文章を都度読み上げられるのを防止。そして、chat_screenに遷移した回数分、音声が重…

### DIFF
--- a/lib/data/repositories/google_text_to_speech_repository.dart
+++ b/lib/data/repositories/google_text_to_speech_repository.dart
@@ -4,7 +4,16 @@ import 'package:http/http.dart' as http;
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
+List<String> spokenMessages = []; // 既に読み上げたメッセージを追跡するリスト
+AudioPlayer? currentAudioPlayer; // 再生中のオーディオプレーヤーを管理する変数
+
 Future<void> speak(String text) async {
+
+  // メッセージが既に読み上げられていないことを確認
+  if (spokenMessages.contains(text)) {
+    return;
+  }
+
   final String apiKey = dotenv.env['TEXT_TO_SPEECH_API_KEY']!;
   final String url =
       'https://texttospeech.googleapis.com/v1/text:synthesize?key=$apiKey';
@@ -31,7 +40,16 @@ Future<void> speak(String text) async {
     if (response.statusCode == 200) {
       final responseBody = jsonDecode(response.body);
       final audioContent = base64Decode(responseBody['audioContent']);
-      await audioPlayer.play(BytesSource(audioContent));
+
+      // 既に再生中のオーディオがある場合には停止する
+      if (currentAudioPlayer != null) {
+        await currentAudioPlayer!.stop();
+      }
+
+      // 新しいオーディオプレーヤーを作成して再生
+      currentAudioPlayer = AudioPlayer();
+      await currentAudioPlayer!.play(BytesSource(audioContent));
+      spokenMessages.add(text); // 読み上げが完了したら、spokenMessages リストに追加
     } else {
       debugPrint('Error: ${response.statusCode}');
       debugPrint('Response body: ${response.body}');

--- a/lib/ui/screens/ai_screen/voice_screen.dart
+++ b/lib/ui/screens/ai_screen/voice_screen.dart
@@ -31,6 +31,7 @@ class VoiceScreen extends ConsumerStatefulWidget {
 
 class VoiceScreenState extends ConsumerState<VoiceScreen> {
   String? lastSpokenMessage;
+  List<String> spokenMessages = []; // 既に読み上げたメッセージを追跡するリスト
 
   @override
   void initState() {
@@ -45,7 +46,9 @@ class VoiceScreenState extends ConsumerState<VoiceScreen> {
 
     if (message != null &&
         message.text != lastSpokenMessage &&
-        messages.length != 1) {
+        messages.length != 1 &&
+        !spokenMessages.contains(message.text) // 新しいメッセージが既に読み上げられていないことを確認
+      ) { 
       lastSpokenMessage = message.text;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         speak(message.text);


### PR DESCRIPTION
Close #91 

- Home_Screenに遷移する度に読み上げ済の文章を都度読み上げられるのを防止
- chat_screenに遷移した回数分、音声が重なる現象の防止